### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -29,7 +29,7 @@ jobs:
       uses: managedkaos/print-env@v1.0
 
     - name: Build & Publish to Github Container Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ github.actor }}/${{ env.IMAGE_NAME }}
         username: ${{ github.actor }}
@@ -40,7 +40,7 @@ jobs:
         tags: "${{ env.IMAGE_TAG }}"
 
     - name: Build & Publish to DockerHub
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ github.actor }}/${{ env.IMAGE_NAME }}
         username: ${{ github.actor }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore